### PR TITLE
Update image tags to fix vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Updated
+
+- Upgrade container image for agent from 7.38.2 to 7.40.0 ([changelog](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst))
+- Upgrade container image for cluster-agent from 1.22.0 to 7.40.0 ([changelog](https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG-DCA.rst)). 
+  Note: Despite the major version change, no breaking changes are stated by Datadog. The major version change is due to aligning
+  the versioning of agent and cluster-agent with version 7.39.0.
+
 ## [2.4.0] - 2022-08-29
 
 ### Changed

--- a/helm/datadog/values.yaml
+++ b/helm/datadog/values.yaml
@@ -695,7 +695,7 @@ clusterAgent:
     name: cluster-agent
 
     # clusterAgent.image.tag -- Cluster Agent image tag to use
-    tag: 1.22.0
+    tag: 7.40.0
 
     # clusterAgent.image.digest -- Cluster Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1008,7 +1008,7 @@ agents:
     name: agent
 
     # agents.image.tag -- Define the Agent version to use
-    tag: 7.38.2
+    tag: 7.40.0
 
     # agents.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""
@@ -1446,7 +1446,7 @@ clusterChecksRunner:
     name: agent
 
     # clusterChecksRunner.image.tag -- Define the Agent version to use
-    tag: 7.38.2
+    tag: 7.40.0
 
     # clusterChecksRunner.image.digest -- Define Agent image digest to use, takes precedence over tag if specified
     digest: ""


### PR DESCRIPTION
Hi :) On November 1st, openssl published two vulnerabilities (CVE-2022-3786, CVE-2022-3602) with criticality "HIGH". This PR is intended to upgrade the docker image tag, since only the newest tags have received new image builds containing a fixed libssl.

Datadog ships its own bundled openssl 1.1.1, but the vulnerable version 3.x is still present in the image.

I'm not sure whether the changes in this PR are the only steps necessary for you to bump all images.

The large bump in the cluster-agent is due to datadog aligning the cluster-agent versioning with the agent in version 7.39.0.